### PR TITLE
minor naming fixes

### DIFF
--- a/16_rbac.tf
+++ b/16_rbac.tf
@@ -41,7 +41,7 @@ resource "kubernetes_cluster_role_v1" "clusterRole" {
   dynamic "rule" {
     for_each = var.rbac.clusterRoleRules
     content {
-      api_groups = rule.value.api_groups
+      api_groups = rule.value.apiGroups
       resources  = rule.value.resources
       verbs      = rule.value.verbs
     }
@@ -84,7 +84,7 @@ resource "kubernetes_role_v1" "role" {
   dynamic "rule" {
     for_each = var.rbac.roleRules
     content {
-      api_groups = rule.value.api_groups
+      api_groups = rule.value.apiGroups
       resources  = rule.value.resources
       verbs      = rule.value.verbs
     }

--- a/23_release.tf
+++ b/23_release.tf
@@ -1,3 +1,3 @@
 output "version" {
-  value = "1.2.0"
+  value = "1.2.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1] - 2022-02-17
+
+- fix apiGroup value name
+- fix example HTTP scheme values
+
 ## [1.2.0] - 2022-02-16
 
 - add `sourceRanges` to `var.service.loadBalancer` to enable configuration of allowed sources

--- a/example/module/submodules/replaceMe/10_containers.tf
+++ b/example/module/submodules/replaceMe/10_containers.tf
@@ -45,7 +45,7 @@ locals {
           path    = "/"
           port    = "replaceMe"
           host    = ""
-          scheme  = "http"
+          scheme  = "HTTP"
           header  = {}
         }
         tcpSocket = {
@@ -63,7 +63,7 @@ locals {
           path    = "/"
           port    = "replaceMe"
           host    = ""
-          scheme  = "http"
+          scheme  = "HTTP"
           header  = {}
         }
         tcpSocket = {
@@ -89,7 +89,7 @@ locals {
             path    = "/"
             port    = "replaceMe"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {
@@ -114,7 +114,7 @@ locals {
             path    = "/"
             port    = "replaceMe"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {
@@ -139,7 +139,7 @@ locals {
             path    = "/"
             port    = "replaceMe"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {

--- a/test/ubuntu/submodules/ubuntu/10_containers.tf
+++ b/test/ubuntu/submodules/ubuntu/10_containers.tf
@@ -37,7 +37,7 @@ locals {
           path    = "/"
           port    = "none"
           host    = ""
-          scheme  = "http"
+          scheme  = "HTTP"
           header  = {}
         }
         tcpSocket = {
@@ -55,7 +55,7 @@ locals {
           path    = "/"
           port    = "none"
           host    = ""
-          scheme  = "http"
+          scheme  = "HTTP"
           header  = {}
         }
         tcpSocket = {
@@ -81,7 +81,7 @@ locals {
             path    = "/"
             port    = "none"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {
@@ -106,7 +106,7 @@ locals {
             path    = "/"
             port    = "none"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {
@@ -131,7 +131,7 @@ locals {
             path    = "/"
             port    = "none"
             host    = ""
-            scheme  = "http"
+            scheme  = "HTTP"
             header  = {}
           }
           tcpSocket = {


### PR DESCRIPTION
Minor naming fixes, these currently prevent the Terraform code from being applied. 

- fix apiGroup value name
- fix example scheme value