### PR TITLE
release 1.2.2: fix missing role namespace for rbac rules

### DIFF
--- a/16_rbac.tf
+++ b/16_rbac.tf
@@ -77,8 +77,8 @@ resource "kubernetes_role_v1" "role" {
   count = length(var.rbac.roleRules) > 0 ? 1 : 0
 
   metadata {
-    name   = var.consistency.hard.namespaceUniqueName
-    labels = var.consistency.soft.labels
+    name      = var.consistency.hard.namespaceUniqueName
+    labels    = var.consistency.soft.labels
     namespace = var.consistency.hard.namespace
   }
 

--- a/16_rbac.tf
+++ b/16_rbac.tf
@@ -79,6 +79,7 @@ resource "kubernetes_role_v1" "role" {
   metadata {
     name   = var.consistency.hard.namespaceUniqueName
     labels = var.consistency.soft.labels
+    namespace = var.consistency.hard.namespace
   }
 
   dynamic "rule" {

--- a/23_release.tf
+++ b/23_release.tf
@@ -1,3 +1,3 @@
 output "version" {
-  value = "1.2.1"
+  value = "1.2.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2] - 2022-02-17
+
+- fix missing role namespace for rbac rules
+
 ## [1.2.1] - 2022-02-17
 
 - fix apiGroup value name


### PR DESCRIPTION
release 1.2.2: fix missing role namespace for rbac rules