### PR TITLE
replace kubernetes_horizontal_pod_autoscaler_v2beta2

### DIFF
--- a/18_horizontalPodAutoscaler.tf
+++ b/18_horizontalPodAutoscaler.tf
@@ -2,7 +2,7 @@ locals {
   horizontalPodAutoscalerEnabled = contains(["deployment", "statefulset"], var.podResourceType) ? var.podResourceTypeConfig.minReplicas < var.podResourceTypeConfig.maxReplicas ? var.horizontalPodAutoscaler.enabled : false : false
 }
 
-resource "kubernetes_horizontal_pod_autoscaler_v2beta2" "horizontalPodAutoscaler" {
+resource "kubernetes_horizontal_pod_autoscaler_v2" "horizontalPodAutoscaler" {
   count = local.horizontalPodAutoscalerEnabled ? 1 : 0
 
   metadata {


### PR DESCRIPTION
The autoscaling/v2beta2 API version of HorizontalPodAutoscaler is no longer served as of v1.26.
Migrate manifests and API clients to use the autoscaling/v2 API version, available since v1.23.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26
