### PR TITLE
added seccomp_profile & tf fmt

### DIFF
--- a/01_deployment.tf
+++ b/01_deployment.tf
@@ -228,6 +228,14 @@ resource "kubernetes_deployment_v1" "deployment" {
               run_as_group              = init_container.value.securityContext.runAsGroup
               run_as_non_root           = init_container.value.securityContext.runAsNonRoot
               run_as_user               = init_container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = init_container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = init_container.value.stdin
             stdin_once                 = init_container.value.stdinOnce
@@ -418,7 +426,7 @@ resource "kubernetes_deployment_v1" "deployment" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -435,7 +443,7 @@ resource "kubernetes_deployment_v1" "deployment" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -482,6 +490,14 @@ resource "kubernetes_deployment_v1" "deployment" {
               run_as_group              = container.value.securityContext.runAsGroup
               run_as_non_root           = container.value.securityContext.runAsNonRoot
               run_as_user               = container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = container.value.stdin
             stdin_once                 = container.value.stdinOnce
@@ -811,7 +827,7 @@ resource "kubernetes_deployment_v1" "deployment" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -828,7 +844,7 @@ resource "kubernetes_deployment_v1" "deployment" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 

--- a/01_deployment.tf
+++ b/01_deployment.tf
@@ -230,10 +230,10 @@ resource "kubernetes_deployment_v1" "deployment" {
               run_as_user               = init_container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                for_each = init_container.value.securityContext.seccompProfile.type != null ? [init_container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = init_container.value.securityContext.seccomp_profile.type
+                  localhost_profile = init_container.value.securityContext.seccompProfile.localhostProfile
+                  type              = init_container.value.securityContext.seccompProfile.type
                 }
               }
             }
@@ -492,10 +492,10 @@ resource "kubernetes_deployment_v1" "deployment" {
               run_as_user               = container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                for_each = container.value.securityContext.seccompProfile.type != null ? [container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = container.value.securityContext.seccomp_profile.type
+                  localhost_profile = container.value.securityContext.seccompProfile.localhostProfile
+                  type              = container.value.securityContext.seccompProfile.type
                 }
               }
             }

--- a/02_daemonset.tf
+++ b/02_daemonset.tf
@@ -217,10 +217,10 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               run_as_user               = init_container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                for_each = init_container.value.securityContext.seccompProfile.type != null ? [init_container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = init_container.value.securityContext.seccomp_profile.type
+                  localhost_profile = init_container.value.securityContext.seccompProfile.localhostProfile
+                  type              = init_container.value.securityContext.seccompProfile.type
                 }
               }
             }
@@ -470,10 +470,10 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               run_as_user               = container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                for_each = container.value.securityContext.seccompProfile.type != null ? [container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = container.value.securityContext.seccomp_profile.type
+                  localhost_profile = container.value.securityContext.seccompProfile.localhostProfile
+                  type              = container.value.securityContext.seccompProfile.type
                 }
               }
             }

--- a/02_daemonset.tf
+++ b/02_daemonset.tf
@@ -215,6 +215,14 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               run_as_group              = init_container.value.securityContext.runAsGroup
               run_as_non_root           = init_container.value.securityContext.runAsNonRoot
               run_as_user               = init_container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = init_container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = init_container.value.stdin
             stdin_once                 = init_container.value.stdinOnce
@@ -396,7 +404,7 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -413,7 +421,7 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -460,6 +468,14 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               run_as_group              = container.value.securityContext.runAsGroup
               run_as_non_root           = container.value.securityContext.runAsNonRoot
               run_as_user               = container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = container.value.stdin
             stdin_once                 = container.value.stdinOnce
@@ -781,7 +797,7 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -798,7 +814,7 @@ resource "kubernetes_daemon_set_v1" "daemonset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 

--- a/03_statefulset.tf
+++ b/03_statefulset.tf
@@ -10,8 +10,8 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
   }
 
   spec {
-    service_name = kubernetes_service_v1.clusterIp.0.metadata.0.name
-    replicas     = var.podResourceTypeConfig.minReplicas
+    service_name          = kubernetes_service_v1.clusterIp.0.metadata.0.name
+    replicas              = var.podResourceTypeConfig.minReplicas
     pod_management_policy = var.podResourceTypeConfig.podManagementPolicy
 
     selector {
@@ -234,6 +234,14 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               run_as_group              = init_container.value.securityContext.runAsGroup
               run_as_non_root           = init_container.value.securityContext.runAsNonRoot
               run_as_user               = init_container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = init_container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = init_container.value.stdin
             stdin_once                 = init_container.value.stdinOnce
@@ -424,7 +432,7 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -441,7 +449,7 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -488,6 +496,14 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               run_as_group              = container.value.securityContext.runAsGroup
               run_as_non_root           = container.value.securityContext.runAsNonRoot
               run_as_user               = container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = container.value.stdin
             stdin_once                 = container.value.stdinOnce
@@ -817,7 +833,7 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -834,7 +850,7 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 

--- a/03_statefulset.tf
+++ b/03_statefulset.tf
@@ -236,10 +236,10 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               run_as_user               = init_container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                for_each = init_container.value.securityContext.seccompProfile.type != null ? [init_container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = init_container.value.securityContext.seccomp_profile.type
+                  localhost_profile = init_container.value.securityContext.seccompProfile.localhostProfile
+                  type              = init_container.value.securityContext.seccompProfile.type
                 }
               }
             }
@@ -498,10 +498,10 @@ resource "kubernetes_stateful_set_v1" "statefulset" {
               run_as_user               = container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                for_each = container.value.securityContext.seccompProfile.type != null ? [container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = container.value.securityContext.seccomp_profile.type
+                  localhost_profile = container.value.securityContext.seccompProfile.localhostProfile
+                  type              = container.value.securityContext.seccompProfile.type
                 }
               }
             }

--- a/04_cronJob.tf
+++ b/04_cronJob.tf
@@ -226,6 +226,14 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   run_as_group              = init_container.value.securityContext.runAsGroup
                   run_as_non_root           = init_container.value.securityContext.runAsNonRoot
                   run_as_user               = init_container.value.securityContext.runAsUser
+
+                  dynamic "seccomp_profile" {
+                    for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                    content {
+                      localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
+                      type              = init_container.value.securityContext.seccomp_profile.type
+                    }
+                  }
                 }
                 stdin                      = init_container.value.stdin
                 stdin_once                 = init_container.value.stdinOnce
@@ -416,7 +424,7 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   content {
                     mount_path = volume_mount.value.path
                     name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                    sub_path = volume_mount.value.file
+                    sub_path   = volume_mount.value.file
                   }
                 }
 
@@ -433,7 +441,7 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   content {
                     mount_path = volume_mount.value.path
                     name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                    sub_path = volume_mount.value.file
+                    sub_path   = volume_mount.value.file
                   }
                 }
 
@@ -480,6 +488,14 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   run_as_group              = container.value.securityContext.runAsGroup
                   run_as_non_root           = container.value.securityContext.runAsNonRoot
                   run_as_user               = container.value.securityContext.runAsUser
+
+                  dynamic "seccomp_profile" {
+                    for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                    content {
+                      localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
+                      type              = container.value.securityContext.seccomp_profile.type
+                    }
+                  }
                 }
                 stdin                      = container.value.stdin
                 stdin_once                 = container.value.stdinOnce
@@ -680,7 +696,7 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   content {
                     mount_path = volume_mount.value.path
                     name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                    sub_path = volume_mount.value.file
+                    sub_path   = volume_mount.value.file
                   }
                 }
 
@@ -697,7 +713,7 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   content {
                     mount_path = volume_mount.value.path
                     name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                    sub_path = volume_mount.value.file
+                    sub_path   = volume_mount.value.file
                   }
                 }
 

--- a/04_cronJob.tf
+++ b/04_cronJob.tf
@@ -228,10 +228,10 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   run_as_user               = init_container.value.securityContext.runAsUser
 
                   dynamic "seccomp_profile" {
-                    for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                    for_each = init_container.value.securityContext.seccompProfile.type != null ? [init_container.value.securityContext.seccompProfile] : []
                     content {
-                      localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
-                      type              = init_container.value.securityContext.seccomp_profile.type
+                      localhost_profile = init_container.value.securityContext.seccompProfile.localhostProfile
+                      type              = init_container.value.securityContext.seccompProfile.type
                     }
                   }
                 }
@@ -490,10 +490,10 @@ resource "kubernetes_cron_job_v1" "cronJob" {
                   run_as_user               = container.value.securityContext.runAsUser
 
                   dynamic "seccomp_profile" {
-                    for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                    for_each = container.value.securityContext.seccompProfile.type != null ? [container.value.securityContext.seccompProfile] : []
                     content {
-                      localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
-                      type              = container.value.securityContext.seccomp_profile.type
+                      localhost_profile = container.value.securityContext.seccompProfile.localhostProfile
+                      type              = container.value.securityContext.seccompProfile.type
                     }
                   }
                 }

--- a/05_job.tf
+++ b/05_job.tf
@@ -210,10 +210,10 @@ resource "kubernetes_job_v1" "job" {
               run_as_user               = init_container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                for_each = init_container.value.securityContext.seccompProfile.type != null ? [init_container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = init_container.value.securityContext.seccomp_profile.type
+                  localhost_profile = init_container.value.securityContext.seccompProfile.localhostProfile
+                  type              = init_container.value.securityContext.seccompProfile.type
                 }
               }
             }
@@ -463,10 +463,10 @@ resource "kubernetes_job_v1" "job" {
               run_as_user               = container.value.securityContext.runAsUser
 
               dynamic "seccomp_profile" {
-                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                for_each = container.value.securityContext.seccompProfile.type != null ? [container.value.securityContext.seccompProfile] : []
                 content {
-                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
-                  type              = container.value.securityContext.seccomp_profile.type
+                  localhost_profile = container.value.securityContext.seccompProfile.localhostProfile
+                  type              = container.value.securityContext.seccompProfile.type
                 }
               }
             }

--- a/05_job.tf
+++ b/05_job.tf
@@ -208,6 +208,14 @@ resource "kubernetes_job_v1" "job" {
               run_as_group              = init_container.value.securityContext.runAsGroup
               run_as_non_root           = init_container.value.securityContext.runAsNonRoot
               run_as_user               = init_container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = init_container.value.securityContext.seccomp_profile.type != null ? [init_container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = init_container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = init_container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = init_container.value.stdin
             stdin_once                 = init_container.value.stdinOnce
@@ -389,7 +397,7 @@ resource "kubernetes_job_v1" "job" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -406,7 +414,7 @@ resource "kubernetes_job_v1" "job" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -453,6 +461,14 @@ resource "kubernetes_job_v1" "job" {
               run_as_group              = container.value.securityContext.runAsGroup
               run_as_non_root           = container.value.securityContext.runAsNonRoot
               run_as_user               = container.value.securityContext.runAsUser
+
+              dynamic "seccomp_profile" {
+                for_each = container.value.securityContext.seccomp_profile.type != null ? [container.value.securityContext.seccomp_profile] : []
+                content {
+                  localhost_profile = container.value.securityContext.seccomp_profile.localhost_profile
+                  type              = container.value.securityContext.seccomp_profile.type
+                }
+              }
             }
             stdin                      = container.value.stdin
             stdin_once                 = container.value.stdinOnce
@@ -644,7 +660,7 @@ resource "kubernetes_job_v1" "job" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_secret_v1.secretVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 
@@ -661,7 +677,7 @@ resource "kubernetes_job_v1" "job" {
               content {
                 mount_path = volume_mount.value.path
                 name       = kubernetes_config_map_v1.configVolume[volume_mount.value.key].metadata.0.name
-                sub_path = volume_mount.value.file
+                sub_path   = volume_mount.value.file
               }
             }
 

--- a/20_varInitContainers.tf
+++ b/20_varInitContainers.tf
@@ -19,9 +19,9 @@ variable "initContainers" {
       runAsGroup             = optional(string, null)
       runAsNonRoot           = optional(bool, null)
       runAsUser              = optional(string, null)
-      seccomp_profile = optional(object({
-        localhost_profile = optional(string, null)
-        type              = optional(string, null)
+      seccompProfile = optional(object({
+        localhostProfile = optional(string, null)
+        type             = optional(string, null)
       }), {})
     }), {})
 

--- a/20_varInitContainers.tf
+++ b/20_varInitContainers.tf
@@ -19,6 +19,10 @@ variable "initContainers" {
       runAsGroup             = optional(string, null)
       runAsNonRoot           = optional(bool, null)
       runAsUser              = optional(string, null)
+      seccomp_profile = optional(object({
+        localhost_profile = optional(string, null)
+        type              = optional(string, null)
+      }), {})
     }), {})
 
     args = optional(list(string), [])
@@ -32,18 +36,18 @@ variable "initContainers" {
         cpu    = optional(string, null)
         memory = optional(string, null)
       }), {})
-    })), { default = {}})
+    })), { default = {} })
 
     customCommand = optional(object({
       enabled = bool
       data    = string
-    }), { enabled = false, data = ""})
+    }), { enabled = false, data = "" })
 
     preStop = optional(object({
       exec = optional(object({
         enabled = bool
         command = list(string)
-      }), { enabled = false, command = []})
+      }), { enabled = false, command = [] })
       httpGet = optional(object({
         enabled = bool
         path    = optional(string, "/")
@@ -51,18 +55,18 @@ variable "initContainers" {
         host    = optional(string, "")
         scheme  = optional(string, "HTTP")
         header  = optional(map(string), {})
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
       tcpSocket = optional(object({
         enabled = bool
         port    = string
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
     }), {})
 
     postStart = optional(object({
       exec = optional(object({
         enabled = bool
         command = list(string)
-      }), { enabled = false, command = []})
+      }), { enabled = false, command = [] })
       httpGet = optional(object({
         enabled = bool
         path    = optional(string, "/")
@@ -70,11 +74,11 @@ variable "initContainers" {
         host    = optional(string, "")
         scheme  = optional(string, "HTTP")
         header  = optional(map(string), {})
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
       tcpSocket = optional(object({
         enabled = bool
         port    = string
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
     }), {})
 
   }))

--- a/21_varContainers.tf
+++ b/21_varContainers.tf
@@ -19,6 +19,10 @@ variable "containers" {
       runAsGroup             = optional(string, null)
       runAsNonRoot           = optional(bool, null)
       runAsUser              = optional(string, null)
+      seccomp_profile = optional(object({
+        localhost_profile = optional(string, null)
+        type              = optional(string, null)
+      }), {})
     }), {})
 
     args = optional(list(string), [])
@@ -42,18 +46,18 @@ variable "containers" {
         cpu    = optional(string, null)
         memory = optional(string, null)
       }), {})
-    })), { default = {}})
+    })), { default = {} })
 
     customCommand = optional(object({
       enabled = bool
       data    = string
-    }), { enabled = false, data = ""})
+    }), { enabled = false, data = "" })
 
     preStop = optional(object({
       exec = optional(object({
         enabled = bool
         command = list(string)
-      }), { enabled = false, command = []})
+      }), { enabled = false, command = [] })
       httpGet = optional(object({
         enabled = bool
         path    = optional(string, "/")
@@ -61,18 +65,18 @@ variable "containers" {
         host    = optional(string, "")
         scheme  = optional(string, "HTTP")
         header  = optional(map(string), {})
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
       tcpSocket = optional(object({
         enabled = bool
         port    = string
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
     }), {})
 
     postStart = optional(object({
       exec = optional(object({
         enabled = bool
         command = list(string)
-      }), { enabled = false, command = []})
+      }), { enabled = false, command = [] })
       httpGet = optional(object({
         enabled = bool
         path    = optional(string, "/")
@@ -80,11 +84,11 @@ variable "containers" {
         host    = optional(string, "")
         scheme  = optional(string, "HTTP")
         header  = optional(map(string), {})
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
       tcpSocket = optional(object({
         enabled = bool
         port    = string
-      }), { enabled = false, port = null})
+      }), { enabled = false, port = null })
     }), {})
 
     probes = optional(object({
@@ -98,7 +102,7 @@ variable "containers" {
         exec = optional(object({
           enabled = bool
           command = list(string)
-        }), { enabled = false, command = []})
+        }), { enabled = false, command = [] })
         httpGet = optional(object({
           enabled = bool
           path    = optional(string, "/")
@@ -106,11 +110,11 @@ variable "containers" {
           host    = optional(string, "")
           scheme  = optional(string, "HTTP")
           header  = optional(map(string), {})
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
         tcpSocket = optional(object({
           enabled = bool
           port    = string
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
       }), {})
 
       readiness = optional(object({
@@ -123,7 +127,7 @@ variable "containers" {
         exec = optional(object({
           enabled = bool
           command = list(string)
-        }), { enabled = false, command = []})
+        }), { enabled = false, command = [] })
         httpGet = optional(object({
           enabled = bool
           path    = optional(string, "/")
@@ -131,11 +135,11 @@ variable "containers" {
           host    = optional(string, "")
           scheme  = optional(string, "HTTP")
           header  = optional(map(string), {})
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
         tcpSocket = optional(object({
           enabled = bool
           port    = string
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
       }), {})
 
       liveness = optional(object({
@@ -148,7 +152,7 @@ variable "containers" {
         exec = optional(object({
           enabled = bool
           command = list(string)
-        }), { enabled = false, command = []})
+        }), { enabled = false, command = [] })
         httpGet = optional(object({
           enabled = bool
           path    = optional(string, "/")
@@ -156,11 +160,11 @@ variable "containers" {
           host    = optional(string, "")
           scheme  = optional(string, "HTTP")
           header  = optional(map(string), {})
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
         tcpSocket = optional(object({
           enabled = bool
           port    = string
-        }), { enabled = false, port = null})
+        }), { enabled = false, port = null })
       }), {})
     }), {})
 

--- a/21_varContainers.tf
+++ b/21_varContainers.tf
@@ -19,9 +19,9 @@ variable "containers" {
       runAsGroup             = optional(string, null)
       runAsNonRoot           = optional(bool, null)
       runAsUser              = optional(string, null)
-      seccomp_profile = optional(object({
-        localhost_profile = optional(string, null)
-        type              = optional(string, null)
+      seccompProfile = optional(object({
+        localhostProfile = optional(string, null)
+        type             = optional(string, null)
       }), {})
     }), {})
 

--- a/24_release.tf
+++ b/24_release.tf
@@ -1,3 +1,3 @@
 output "version" {
-  value = "2.0.0"
+  value = "2.4.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.0] - 2025-01-01
+
+- added seccomp_profile options for `var.containers` and `var.init_containers`
+
 ## [2.3.1] - 2024-05-21
 
 - fix kubernetes_horizontal_pod_autoscaler_v2 not working because of missing apiVersion config
@@ -13,7 +17,7 @@
 
 ## [2.1.0] - 2024-01-24
 
-- add `podResourceTypeConfig.podManagementPolicy` 
+- add `podResourceTypeConfig.podManagementPolicy`
 
 ## [2.0.0] - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.4.0] - 2025-01-01
 
-- added seccomp_profile options for `var.containers` and `var.init_containers`
+- added seccompProfile options for `var.containers` and `var.init_containers`
 
 ## [2.3.1] - 2024-05-21
 

--- a/example/module/submodules/replaceMe/10_containers.tf
+++ b/example/module/submodules/replaceMe/10_containers.tf
@@ -169,6 +169,10 @@ locals {
         runAsGroup             = null
         runAsNonRoot           = null
         runAsUser              = null
+
+        seccompProfile = {
+          type = "Unconfined"
+        }
       }
     }
   }


### PR DESCRIPTION
feat: add optional support for seccomp_profile in container security_context

- Introduced an optional seccomp_profile block within the security_context of containers.
- The seccomp_profile block includes support for type and localhost_profile fields.
- Ensures backward compatibility by conditionally rendering the seccomp_profile block only when explicitly defined in the input variable.
- Prevents unnecessary changes to existing configurations when no seccomp_profile is provided.
- Refined logic to handle cases where seccomp_profile is omitted, avoiding defaulting to Unconfined.

