### PR TITLE
2.6.1

### DIFF
--- a/14_service.tf
+++ b/14_service.tf
@@ -177,4 +177,8 @@ resource "kubernetes_service_v1" "loadBalancer" {
 
     selector = var.consistency.soft.matchLabels
   }
+
+  lifecycle {
+    ignore_changes = [ spec[0].load_balancer_class ]
+  }
 }

--- a/14_service.tf
+++ b/14_service.tf
@@ -65,7 +65,7 @@ variable "service" {
       annotations                   = optional(map(string), {})
       remapPorts                    = optional(map(string), {})
       forceNodePortType             = optional(bool, false)
-      loadBalancerClass             = optional(string, "")
+      loadBalancerClass             = optional(string, null)
     })), [])
   })
 

--- a/14_service.tf
+++ b/14_service.tf
@@ -65,6 +65,7 @@ variable "service" {
       annotations                   = optional(map(string), {})
       remapPorts                    = optional(map(string), {})
       forceNodePortType             = optional(bool, false)
+      loadBalancerClass             = optional(string, "")
     })), [])
   })
 
@@ -152,6 +153,7 @@ resource "kubernetes_service_v1" "loadBalancer" {
     session_affinity                  = var.service.loadBalancer[count.index].sessionAffinity
     external_traffic_policy           = var.service.loadBalancer[count.index].externalTrafficPolicy
     load_balancer_source_ranges       = var.service.loadBalancer[count.index].sourceRanges
+    load_balancer_class               = var.service.loadBalancer[count.index].loadBalancerClass
 
     dynamic "port" {
       for_each = local.serviceLoadBalancerPortsTcp
@@ -174,9 +176,5 @@ resource "kubernetes_service_v1" "loadBalancer" {
     }
 
     selector = var.consistency.soft.matchLabels
-  }
-
-  lifecycle {
-    ignore_changes = [ spec[0].load_balancer_class ]
   }
 }

--- a/24_release.tf
+++ b/24_release.tf
@@ -1,3 +1,3 @@
 output "version" {
-  value = "2.5.0"
+  value = "2.6.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.6.1] - 2025-10-13
 
-- added loadBalancerClass configuration and removed lifecycle_ignore from the loadbalancer service. Usage is expected to be required in the future. 
+- added loadBalancerClass configuration, usage is expected to be required in the future. 
 
 ## [2.6.0] - 2025-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.6.1] - 2025-10-13
+
+- added loadBalancerClass configuration and removed lifecycle_ignore from the loadbalancer service. Usage is expected to be required in the future. 
+
 ## [2.6.0] - 2025-10-08
 
 - added lifecycle_ignore for `load_balancer_class` to loadbalancer service


### PR DESCRIPTION
Sorry, I've changed my mind. 

Future configurations might start relying on loadBalancerClass: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.14/guide/service/nlb/#configuration

Changing this in the future, will require another major release (due to depending on a service of type loadbalancer which has the load_balancer_class value set), i'd like to prevent this. 